### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 [![smithery badge](https://smithery.ai/badge/@psaboia/mcp-server-playground)](https://smithery.ai/server/@psaboia/mcp-server-playground)
 
+<a href="https://glama.ai/mcp/servers/fylny5odo3">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/fylny5odo3/badge" alt="Server Playground MCP server" />
+</a>
+
 This repository is a playground for experimenting with an MCP Server built with TypeScript. It is a personalized version of the tutorial and video on building an MCP Server, and it is intended both as a learning resource and a platform to test integrations with Calude Desktop and Cursor IDE.
 
 ## Background


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Playground](https://glama.ai/mcp/servers/fylny5odo3) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/fylny5odo3">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/fylny5odo3/badge" alt="Server Playground MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.